### PR TITLE
removed form reset functionality

### DIFF
--- a/Script/ButtonScript.js
+++ b/Script/ButtonScript.js
@@ -33,6 +33,4 @@ function generateButton() {
 
     document.getElementById('generated-html').textContent = htmlCode;
     document.getElementById('generated-css').textContent = cssCode;
-
-    document.getElementById('button-form').reset();
 }


### PR DESCRIPTION
Removed the forms ability to reset itself after generate is clicked because the user would be annoyed having to constantly retype things to see subtle changes.